### PR TITLE
Simplify output to unique IDs and auto-exclude tests

### DIFF
--- a/dbtlist/cli.py
+++ b/dbtlist/cli.py
@@ -52,45 +52,9 @@ def main(
             select=select, exclude=exclude, packages=package_list
         )
 
-        # Output results in dbt list format
+        # Output results as unique IDs
         for node_unique_id in sorted(selected_nodes):
-            # Convert unique_id to dbt list format
-            # e.g., "model.jaffle_shop.customers" -> "jaffle_shop.customers"
-            # e.g., "test.jaffle_shop.unique_customers_customer_id.c5af1ff4b1"
-            # -> "jaffle_shop.unique_customers_customer_id"
-
-            node = new_reader.manifest.nodes.get(node_unique_id)
-            if node:
-                # Build the output name following dbt list format
-                parts = [node.package_name]
-
-                # Handle schema based on dbt conventions
-                if hasattr(node, "schema") and node.schema:
-                    schema = node.schema
-                    # Only add schema if it's not the default package schema
-                    # For staging models, use 'staging' instead of full schema
-                    if "staging" in schema.lower() or "stg" in node.name:
-                        parts.append("staging")
-                    elif (
-                        schema != node.package_name
-                        and "dev" not in schema
-                        and "test" not in schema
-                    ):
-                        parts.append(schema)
-
-                # Add the node name
-                parts.append(node.name)
-
-                output_name = ".".join(parts)
-            else:
-                # Fallback: extract from unique_id
-                parts = node_unique_id.split(".")
-                if len(parts) >= 3:
-                    output_name = ".".join(parts[1:])  # Skip resource_type prefix
-                else:
-                    output_name = node_unique_id
-
-            click.echo(output_name)
+            click.echo(node_unique_id)
 
     except Exception as e:
         click.echo(f"Error: {e}", err=True)

--- a/dbtlist/selector.py
+++ b/dbtlist/selector.py
@@ -61,6 +61,14 @@ class DbtSelector:
                     filtered_nodes.add(node_name)
             selected_nodes = filtered_nodes
 
+        # Always exclude test nodes by default
+        final_nodes = set()
+        for node_name in selected_nodes:
+            node = self.manifest.nodes.get(node_name)
+            if node and node.resource_type != "test":
+                final_nodes.add(node_name)
+        selected_nodes = final_nodes
+
         return selected_nodes
 
     def _apply_selector(self, selector: str) -> Set[str]:


### PR DESCRIPTION
## Summary
- Change output format from processed names to raw unique IDs (e.g., `model.jaffe_shop.customers`)
- Automatically exclude test nodes from all results by default
- Simplifies CLI usage by removing the need for `--exclude "resource_type:test"`

## Test plan
- [x] All existing tests pass
- [x] Manual testing with manifest files confirms unique ID output
- [x] Tests are automatically filtered out without explicit exclusion

🤖 Generated with [Claude Code](https://claude.ai/code)